### PR TITLE
refactor: invert residual parameterization

### DIFF
--- a/src/slope/math.h
+++ b/src/slope/math.h
@@ -213,14 +213,14 @@ updateGradient(Eigen::MatrixXd& gradient,
 
       for (const auto& j : active_set) {
         gradient(j, k) =
-          -(x.col(j).dot(weighted_residual.col(k)) - x_centers(j) * wr_sum) /
+          (x.col(j).dot(weighted_residual.col(k)) - x_centers(j) * wr_sum) /
           (x_scales(j) * n);
       }
     }
   } else {
     for (int k = 0; k < m; ++k) {
       for (const auto& j : active_set) {
-        gradient(j, k) = -x.col(j).dot(weighted_residual.col(k)) / n;
+        gradient(j, k) = x.col(j).dot(weighted_residual.col(k)) / n;
       }
     }
   }
@@ -260,14 +260,14 @@ offsetGradient(Eigen::MatrixXd& gradient,
     // other than means for the centers.
     for (int k = 0; k < m; ++k) {
       for (const auto& j : active_set) {
-        gradient(j, k) +=
+        gradient(j, k) -=
           offset(k) * (x.col(j).sum() / n - x_centers(j)) / x_scales(j);
       }
     }
   } else {
     for (int k = 0; k < m; ++k) {
       for (const auto& j : active_set) {
-        gradient(j, k) += offset(k) * x.col(j).sum() / n;
+        gradient(j, k) -= offset(k) * x.col(j).sum() / n;
       }
     }
   }

--- a/src/slope/objectives/binomial.cpp
+++ b/src/slope/objectives/binomial.cpp
@@ -20,7 +20,7 @@ Binomial::dual(const Eigen::MatrixXd& theta,
   using Eigen::log;
 
   // Clamp probabilities to [p_min, 1-p_min]
-  Eigen::ArrayXd pr = (y - theta).array().min(1.0 - p_min).max(p_min);
+  Eigen::ArrayXd pr = (theta + y).array().min(1.0 - p_min).max(p_min);
 
   return -(pr * log(pr) + (1.0 - pr) * log(1.0 - pr)).mean();
 }
@@ -28,7 +28,7 @@ Binomial::dual(const Eigen::MatrixXd& theta,
 Eigen::MatrixXd
 Binomial::residual(const Eigen::MatrixXd& eta, const Eigen::MatrixXd& y)
 {
-  return y.array() - 1.0 / (1.0 + (-eta).array().exp());
+  return 1.0 / (1.0 + (-eta).array().exp()) - y.array();
 }
 
 Eigen::MatrixXd

--- a/src/slope/objectives/gaussian.cpp
+++ b/src/slope/objectives/gaussian.cpp
@@ -15,13 +15,13 @@ Gaussian::dual(const Eigen::MatrixXd& theta,
 {
   const int n = y.rows();
 
-  return (y.squaredNorm() - (y - theta).squaredNorm()) / (2.0 * n);
+  return (y.squaredNorm() - (theta + y).squaredNorm()) / (2.0 * n);
 }
 
 Eigen::MatrixXd
 Gaussian::residual(const Eigen::MatrixXd& eta, const Eigen::MatrixXd& y)
 {
-  return y - eta;
+  return eta - y;
 }
 
 Eigen::MatrixXd

--- a/src/slope/objectives/gaussian.h
+++ b/src/slope/objectives/gaussian.h
@@ -68,7 +68,7 @@ public:
    * @param y Actual values vector (n x 1)
    * @return Vector of residuals (n x 1)
    *
-   * @note Residuals are calculated as: \f$ r_i = y_i - \eta_i \f$
+   * @note Residuals are calculated as: \f$ r_i = \eta_i - y_i \f$
    */
   Eigen::MatrixXd residual(const Eigen::MatrixXd& eta,
                            const Eigen::MatrixXd& y);

--- a/src/slope/objectives/multinomial.cpp
+++ b/src/slope/objectives/multinomial.cpp
@@ -23,7 +23,7 @@ Multinomial::dual(const Eigen::MatrixXd& theta,
                   const Eigen::MatrixXd& y,
                   const Eigen::VectorXd& w)
 {
-  const Eigen::MatrixXd r = y - theta;
+  const Eigen::MatrixXd r = theta + y;
 
   return -(r.array() * r.array().max(1e-9).log()).sum() / y.rows();
 }
@@ -31,7 +31,7 @@ Multinomial::dual(const Eigen::MatrixXd& theta,
 Eigen::MatrixXd
 Multinomial::residual(const Eigen::MatrixXd& eta, const Eigen::MatrixXd& y)
 {
-  return y - softmax(eta);
+  return softmax(eta) - y;
 }
 
 Eigen::MatrixXd

--- a/src/slope/objectives/objective.h
+++ b/src/slope/objectives/objective.h
@@ -107,7 +107,7 @@ public:
                                const Eigen::MatrixXd& y)
   {
     Eigen::MatrixXd residual = this->residual(eta, y);
-    beta0 += residual.colwise().mean() / this->lipschitz_constant;
+    beta0 -= residual.colwise().mean() / this->lipschitz_constant;
   };
 
   /**

--- a/src/slope/objectives/poisson.cpp
+++ b/src/slope/objectives/poisson.cpp
@@ -13,7 +13,7 @@ Poisson::dual(const Eigen::MatrixXd& theta,
               const Eigen::MatrixXd& y,
               const Eigen::VectorXd& w)
 {
-  const Eigen::ArrayXd e = y - theta;
+  const Eigen::ArrayXd e = theta + y;
 
   assert((e >= 0).all() &&
          "Dual function is not defined for negative residuals");
@@ -24,7 +24,7 @@ Poisson::dual(const Eigen::MatrixXd& theta,
 Eigen::MatrixXd
 Poisson::residual(const Eigen::MatrixXd& eta, const Eigen::MatrixXd& y)
 {
-  return y.array() - eta.array().exp();
+  return eta.array().exp() - y.array();
 }
 
 void
@@ -53,7 +53,7 @@ Poisson::updateIntercept(Eigen::VectorXd& beta0,
                          const Eigen::MatrixXd& y)
 {
   Eigen::VectorXd residual = this->residual(eta, y);
-  double grad = -residual.mean();
+  double grad = residual.mean();
   double hess = eta.array().exp().mean();
 
   beta0(0) -= grad / hess;

--- a/src/slope/objectives/poisson.h
+++ b/src/slope/objectives/poisson.h
@@ -55,7 +55,7 @@ public:
    * regression.
    * @param eta The linear predictor vector \f$\eta\f$
    * @param y The observed counts vector \f$y\f$
-   * @return The residual vector: \f$y - e^{\eta}\f$
+   * @return The residual vector: \f$e^{\eta} - y\f$
    */
   Eigen::MatrixXd residual(const Eigen::MatrixXd& eta,
                            const Eigen::MatrixXd& y) override;

--- a/src/slope/solvers/hybrid.h
+++ b/src/slope/solvers/hybrid.h
@@ -128,7 +128,7 @@ private:
     objective->updateWeightsAndWorkingResponse(w, z, eta, y);
     VectorXd w_sqrt = w.cwiseSqrt();
 
-    VectorXd residual = z - eta;
+    VectorXd residual = eta - z;
     MatrixXd gradient = gradient_in;
 
     for (int it = 0; it < this->max_it_inner; ++it) {
@@ -171,7 +171,7 @@ private:
                            lambda.head(working_set.size()));
         theta.array() /= std::max(1.0, dual_norm);
 
-        double dual_inner = (theta.cwiseProduct(w).dot(z) -
+        double dual_inner = ((-theta).cwiseProduct(w).dot(z) -
                              0.5 * theta.cwiseAbs2().cwiseProduct(w).sum()) /
                             n;
 
@@ -242,7 +242,7 @@ private:
 
     // The residual is kept up to date, but not eta. So we need to compute
     // it here.
-    eta = z - residual;
+    eta = residual + z;
     // TODO: register convergence status
   }
 

--- a/src/slope/solvers/hybrid_cd.h
+++ b/src/slope/solvers/hybrid_cd.h
@@ -30,7 +30,7 @@ computeGradientAndHessian(const T& x,
   double gradient, hessian;
 
   if (standardize_jit) {
-    gradient = -s *
+    gradient = s *
                (x.col(k).cwiseProduct(w).dot(residual) -
                 w.dot(residual) * x_centers(k)) /
                (n * x_scales(k));
@@ -40,7 +40,7 @@ computeGradientAndHessian(const T& x,
        std::pow(x_centers(k), 2) * w.sum()) /
       (std::pow(x_scales(k), 2) * n);
   } else {
-    gradient = -s * (x.col(k).cwiseProduct(w).dot(residual)) / n;
+    gradient = s * (x.col(k).cwiseProduct(w).dot(residual)) / n;
     hessian = x.col(k).cwiseAbs2().dot(w) / n;
   }
 
@@ -136,7 +136,7 @@ coordinateDescent(Eigen::VectorXd& beta0,
       }
 
       hessian_j = x_s.cwiseAbs2().dot(w) / n;
-      gradient_j = -x_s.cwiseProduct(w).dot(residual) / n;
+      gradient_j = x_s.cwiseProduct(w).dot(residual) / n;
     }
 
     auto [c_tilde, new_index] = slopeThreshold(
@@ -155,13 +155,13 @@ coordinateDescent(Eigen::VectorXd& beta0,
         int k = *clusters.cbegin(j);
 
         if (standardize_jit) {
-          residual += x.col(k) * (s[0] * c_diff / x_scales(k));
-          residual.array() -= x_centers(k) * s[0] * c_diff / x_scales(k);
+          residual -= x.col(k) * (s[0] * c_diff / x_scales(k));
+          residual.array() += x_centers(k) * s[0] * c_diff / x_scales(k);
         } else {
-          residual += x.col(k) * (s[0] * c_diff);
+          residual -= x.col(k) * (s[0] * c_diff);
         }
       } else {
-        residual += x_s * c_diff;
+        residual -= x_s * c_diff;
       }
     }
 
@@ -176,7 +176,7 @@ coordinateDescent(Eigen::VectorXd& beta0,
       // of after each coordinate update
       double beta0_update = residual.dot(w) / n;
       residual.array() -= beta0_update;
-      beta0(0) += beta0_update;
+      beta0(0) -= beta0_update;
     }
   }
 }

--- a/src/slope/solvers/hybrid_pgd.h
+++ b/src/slope/solvers/hybrid_pgd.h
@@ -81,17 +81,18 @@ proximalGradientDescent(Eigen::VectorXd& beta0,
 
     if (intercept) {
       double intercept_update = residual.dot(w) / n;
-      beta0(0) += intercept_update;
+      beta0(0) -= intercept_update;
     }
 
-    residual = z - linearPredictor(x,
-                                   working_set,
-                                   beta0,
-                                   beta,
-                                   x_centers,
-                                   x_scales,
-                                   standardize_jit,
-                                   intercept);
+    residual = linearPredictor(x,
+                               working_set,
+                               beta0,
+                               beta,
+                               x_centers,
+                               x_scales,
+                               standardize_jit,
+                               intercept) -
+               z;
 
     double g = (0.5 / n) * residual.cwiseAbs2().dot(w);
     double q = g_old + beta_diff.dot(gradient_active) +

--- a/tests/screening.cpp
+++ b/tests/screening.cpp
@@ -45,8 +45,8 @@ TEST_CASE("Strong screening rule", "[screening]")
     // Modified, incorrect solution, which should now have a KKT violation
     beta_hat(0) = 0.0;
 
-    residual = y - x * beta_hat;
-    gradient = -x.transpose() * residual;
+    residual = x * beta_hat - y;
+    gradient = x.transpose() * residual;
 
     auto violations = kktCheck(gradient, beta_hat, lambda, { 0, 1, 2 });
 
@@ -58,8 +58,8 @@ TEST_CASE("Strong screening rule", "[screening]")
     lambda *= 10 * 1.25 * n;
     beta_hat << 0.0, 0.09096501, 0.0;
 
-    residual = y - x * beta_hat;
-    gradient = -x.transpose() * residual;
+    residual = x * beta_hat - y;
+    gradient = x.transpose() * residual;
 
     Eigen::ArrayXd lambda_prev = lambda;
     lambda *= 0.99;

--- a/tests/standardize.cpp
+++ b/tests/standardize.cpp
@@ -73,7 +73,7 @@ TEST_CASE("Check that in-place standardization works",
   Eigen::VectorXd y = x_dense * beta;
   Eigen::VectorXd w = Eigen::VectorXd::Ones(3); // weights
 
-  Eigen::VectorXd residual = y;
+  Eigen::VectorXd residual = -y;
   residual(0) += 1;
   residual(1) += -0.2;
   residual(2) += 0.9;
@@ -85,13 +85,13 @@ TEST_CASE("Check that in-place standardization works",
   REQUIRE_THAT(x_scales_dense, VectorApproxEqual(x_scales_sparse));
 
   Eigen::VectorXd residual_dense =
-    y - x_dense * beta.cwiseQuotient(x_scales_dense);
-  residual_dense.array() +=
+    x_dense * beta.cwiseQuotient(x_scales_dense) - y;
+  residual_dense.array() -=
     x_centers_dense.cwiseQuotient(x_scales_dense).dot(beta);
 
   Eigen::VectorXd residual_sparse =
-    y - x_sparse * beta.cwiseQuotient(x_scales_sparse);
-  residual_sparse.array() +=
+    x_sparse * beta.cwiseQuotient(x_scales_sparse) - y;
+  residual_sparse.array() -=
     x_centers_sparse.cwiseQuotient(x_scales_sparse).dot(beta);
 
   REQUIRE_THAT(residual_dense, VectorApproxEqual(residual_sparse));
@@ -154,7 +154,7 @@ TEST_CASE("JIT standardization and modify-X standardization",
   Eigen::VectorXd y = x * beta;
   Eigen::VectorXd w = Eigen::VectorXd::Ones(n); // weights
 
-  Eigen::VectorXd residual = y;
+  Eigen::VectorXd residual = -y;
   residual(0) += 1;
   residual(1) -= 0.2;
   residual(2) += 0.9;


### PR DESCRIPTION
Revert parameterization of residual, so that now X^T residual =
gradient. This is of no real consequence and just a matter of
convenience in order to avoid tripping up on this in the future.