### PR TITLE
feat!: Separate `fit()` and `path()` methods

### DIFF
--- a/src/slope/slope.h
+++ b/src/slope/slope.h
@@ -5,11 +5,12 @@
 
 #pragma once
 
+#include "slope_fit.h"
+#include "slope_path.h"
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 #include <cassert>
 #include <optional>
-#include <vector>
 
 namespace slope {
 
@@ -223,84 +224,21 @@ public:
    */
   void setMaxClusters(const int max_clusters);
 
-  /**
-   * @brief Get the alpha sequence.
-   *
-   * @return The sequence of weights for the regularization path.
-   */
-  const Eigen::ArrayXd& getAlpha() const;
-
-  /**
-   * @brief Get the lambda sequence.
-   *
-   * @return The sequence of lambda values for the weights of the sorted L1
-   * norm.
-   */
-  const Eigen::ArrayXd& getLambda() const;
-
-  /**
-   * Get the coefficients from the path.
-   *
-   * @return The coefficients from the path, stored in a sparse matrix.
-   */
-  const std::vector<Eigen::SparseMatrix<double>> getCoefs() const;
-
-  /**
-   * Get the intercepts from the path.
-   *
-   * @return The coefficients from the path, stored in an Eigen vector. If no
-   * intercepts were fit, this is a vector of zeros.
-   */
-  const std::vector<Eigen::VectorXd> getIntercepts() const;
-
-  /**
-   * Get the total number of (inner) iterations.
-   *
-   * @return The toral number of iterations from the inner loop, computed across
-   * the path.
-   */
-  int getTotalIterations() const;
-
-  /**
-   * Get the duality gaps.
-   *
-   * @return Get the duality gaps from the path.
-   */
-  const std::vector<std::vector<double>>& getDualGaps() const;
-
-  /**
-   * Get the primal objective values.
-   *
-   * @return Get the primal objective values from the path.
-   */
-  const std::vector<std::vector<double>>& getPrimals() const;
-
-  /**
-   * Get the deviances
-   *
-   * @return Get the primal objective values from the path.
-   */
-  const std::vector<double>& getDeviances() const;
-
-  /**
-   * Get the deviance for the null model
-   *
-   * @return Get the primal objective values from the path.
-   */
-  const double& getNullDeviance() const;
+  // Declaration of the templated path() method.
+  template<typename T>
+  SlopePath path(T& x,
+                 const Eigen::MatrixXd& y_in,
+                 Eigen::ArrayXd alpha = Eigen::ArrayXd::Zero(0),
+                 Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(0));
 
   // Declaration of the templated fit() method.
   template<typename T>
-  void fit(T& x,
-           const Eigen::MatrixXd& y_in,
-           Eigen::ArrayXd alpha = Eigen::ArrayXd::Zero(0),
-           Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(0));
+  SlopeFit fit(T& x,
+               const Eigen::MatrixXd& y_in,
+               const double alpha = 1.0,
+               Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(0));
 
 private:
-  // Reset the output values, but not the current coefficients
-  void reset();
-
-  // parameters
   bool intercept;
   bool modify_x;
   bool standardize;
@@ -321,19 +259,6 @@ private:
   std::string objective;
   std::string screening_type;
   std::string solver_type;
-
-  // estimates
-  Eigen::ArrayXd alpha_out;
-  Eigen::ArrayXd lambda_out;
-  Eigen::MatrixXd beta;
-  Eigen::VectorXd beta0;
-  double null_deviance;
-  int it_total;
-  std::vector<Eigen::SparseMatrix<double>> betas;
-  std::vector<Eigen::VectorXd> beta0s;
-  std::vector<double> deviances;
-  std::vector<std::vector<double>> dual_gaps_path;
-  std::vector<std::vector<double>> primals_path;
 };
 
 } // namespace slope

--- a/src/slope/slope_fit.h
+++ b/src/slope/slope_fit.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+
+namespace slope {
+
+class SlopeFit
+{
+private:
+  Eigen::VectorXd intercepts;
+  Eigen::SparseMatrix<double> coefs;
+  Eigen::ArrayXd lambda;
+  double deviance;
+  double null_deviance;
+  std::vector<double> primals;
+  std::vector<double> duals;
+
+public:
+  SlopeFit() = default;
+
+  SlopeFit(const Eigen::VectorXd& intercepts,
+           const Eigen::SparseMatrix<double>& coefs,
+           const Eigen::ArrayXd& lambda,
+           double deviance,
+           double null_deviance,
+           const std::vector<double>& primals,
+           const std::vector<double>& duals)
+    : intercepts{ intercepts }
+    , coefs{ coefs }
+    , lambda{ lambda }
+    , deviance{ deviance }
+    , null_deviance{ null_deviance }
+    , primals{ primals }
+    , duals{ duals }
+  {
+  }
+
+  const Eigen::VectorXd& getIntercepts() const { return intercepts; }
+  const Eigen::SparseMatrix<double>& getCoefs() const { return coefs; }
+  const Eigen::ArrayXd& getLambda() const { return lambda; }
+  double getDeviance() const { return deviance; }
+  double getNullDeviance() const { return null_deviance; }
+  const std::vector<double>& getPrimals() const { return primals; }
+  const std::vector<double>& getDuals() const { return duals; }
+
+  double getDevianceRatios() const { return 1.0 - deviance / null_deviance; }
+
+  std::vector<double> getGaps() const
+  {
+    std::vector<double> gaps(primals.size());
+
+    for (size_t i = 0; i < primals.size(); i++) {
+      gaps[i] = primals[i] - duals[i];
+    }
+
+    return gaps;
+  }
+};
+
+} // namespace slope

--- a/src/slope/slope_path.h
+++ b/src/slope/slope_path.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+
+namespace slope {
+
+class SlopePath
+{
+private:
+  std::vector<Eigen::VectorXd> intercepts;
+  std::vector<Eigen::SparseMatrix<double>> coefs;
+  Eigen::ArrayXd alpha;
+  Eigen::ArrayXd lambda;
+  std::vector<double> deviance;
+  double null_deviance;
+  std::vector<std::vector<double>> primals;
+  std::vector<std::vector<double>> duals;
+
+public:
+  SlopePath() = default;
+
+  SlopePath(const std::vector<Eigen::VectorXd>& intercepts,
+            const std::vector<Eigen::SparseMatrix<double>>& coefs,
+            const Eigen::ArrayXd& alpha,
+            const Eigen::ArrayXd& lambda,
+            const std::vector<double>& deviance,
+            double null_deviance,
+            const std::vector<std::vector<double>>& primals,
+            const std::vector<std::vector<double>>& duals)
+    : intercepts{ intercepts }
+    , coefs{ coefs }
+    , alpha{ alpha }
+    , lambda{ lambda }
+    , deviance{ deviance }
+    , null_deviance{ null_deviance }
+    , primals{ primals }
+    , duals{ duals }
+  {
+  }
+
+  const std::vector<Eigen::VectorXd>& getIntercepts() const
+  {
+    return intercepts;
+  }
+
+  const std::vector<Eigen::SparseMatrix<double>>& getCoefs() const
+  {
+    return coefs;
+  }
+
+  const Eigen::SparseMatrix<double>& getCoefs(const std::size_t i) const
+  {
+    assert(i >= 0 && i < coefs.size() && "Index out of bounds");
+    return coefs[i];
+  }
+
+  const Eigen::ArrayXd& getAlpha() const { return alpha; }
+  const Eigen::ArrayXd& getLambda() const { return lambda; }
+  const std::vector<double>& getDeviance() const { return deviance; }
+  double getNullDeviance() const { return null_deviance; }
+  const std::vector<std::vector<double>>& getPrimals() const { return primals; }
+  const std::vector<std::vector<double>>& getDuals() const { return duals; }
+
+  const std::vector<double> getDevianceRatios() const
+  {
+    std::vector<double> ratios(deviance.size());
+
+    for (size_t i = 0; i < deviance.size(); i++) {
+      ratios[i] = 1.0 - deviance[i] / null_deviance;
+    }
+
+    return ratios;
+  }
+
+  const std::vector<std::vector<double>> getGaps() const
+  {
+    std::vector<std::vector<double>> gaps(primals.size());
+
+    for (size_t i = 0; i < primals.size(); i++) {
+      gaps[i].resize(primals[i].size());
+
+      for (size_t j = 0; j < primals[i].size(); j++) {
+        gaps[i][j] = primals[i][j] - duals[i][j];
+      }
+    }
+
+    return gaps;
+  }
+};
+
+} // namespace slope

--- a/tests/normalization.cpp
+++ b/tests/normalization.cpp
@@ -200,17 +200,17 @@ TEST_CASE("JIT standardization and modify-X standardization",
                  VectorApproxEqual(gradient.reshaped(), 1e-6));
   }
 
-  model.fit(x_copy, y);
+  auto fit = model.path(x_copy, y);
 
-  Eigen::VectorXd coefs_ref = model.getCoefs().front();
+  Eigen::VectorXd coefs_ref = fit.getCoefs().back();
 
   SECTION("JIT standardization for dense X")
   {
     model.setModifyX(false);
 
-    model.fit(x, y);
+    fit = model.path(x, y);
 
-    Eigen::VectorXd coefs_mod = model.getCoefs().front();
+    Eigen::VectorXd coefs_mod = fit.getCoefs().back();
 
     REQUIRE_THAT(coefs_mod, VectorApproxEqual(coefs_ref, 1e-6));
   }
@@ -220,9 +220,9 @@ TEST_CASE("JIT standardization and modify-X standardization",
     // Never modify sparse X
     model.setModifyX(false);
 
-    model.fit(x_sparse, y);
+    fit = model.path(x_sparse, y);
 
-    Eigen::VectorXd coefs_sparse = model.getCoefs().front();
+    Eigen::VectorXd coefs_sparse = fit.getCoefs().back();
 
     REQUIRE_THAT(coefs_sparse, VectorApproxEqual(coefs_ref, 1e-6));
   }

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -34,9 +34,9 @@ TEST_CASE("Path fitting", "[path][gaussian]")
     slope::Slope model;
     model.setObjective("gaussian");
 
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.path(x, y, alpha, lambda);
 
-    Eigen::VectorXd coef = model.getCoefs()[2];
+    Eigen::VectorXd coef = fit.getCoefs(2);
     std::vector<double> coef_true = { 0.4487011, 0.6207310 };
 
     REQUIRE_THAT(coef, VectorApproxEqual(coef_true, 1e-4));
@@ -50,10 +50,10 @@ TEST_CASE("Path fitting", "[path][gaussian]")
 
     slope::Slope model;
     model.setPathLength(20);
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.path(x, y, alpha, lambda);
 
-    auto coefs = model.getCoefs();
-    alpha = model.getAlpha();
+    auto coefs = fit.getCoefs();
+    alpha = fit.getAlpha();
 
     REQUIRE(alpha.rows() == 20);
 
@@ -77,12 +77,11 @@ TEST_CASE("Path fitting", "[path][gaussian]")
 
     auto data = generateData(100, 200);
 
-    model.fit(data.x, data.y);
+    auto path = model.path(data.x, data.y);
 
-    auto null_deviance = model.getNullDeviance();
-    auto deviances = model.getDeviances();
-
-    int path_length = deviances.size();
+    auto null_deviance = path.getNullDeviance();
+    auto deviances = path.getDeviance();
+    auto path_length = deviances.size();
 
     REQUIRE(null_deviance >= 0);
     REQUIRE(deviances.size() > 0);
@@ -90,15 +89,15 @@ TEST_CASE("Path fitting", "[path][gaussian]")
     REQUIRE_THAT(deviances, VectorMonotonic(false, true));
 
     model.setDevRatioTol(0.99);
-    model.fit(data.x, data.y);
+    auto fit = model.path(data.x, data.y);
 
-    REQUIRE(model.getDeviances().size() < path_length);
+    REQUIRE(fit.getDeviance().size() < path_length);
 
-    path_length = model.getDeviances().size();
+    path_length = fit.getDeviance().size();
 
     model.setDevChangeTol(0.1);
-    model.fit(data.x, data.y);
+    fit = model.path(data.x, data.y);
 
-    REQUIRE(model.getDeviances().size() < path_length);
+    REQUIRE(fit.getDeviance().size() < path_length);
   }
 }

--- a/tests/poisson.cpp
+++ b/tests/poisson.cpp
@@ -30,10 +30,9 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
   y << 2, 0, 1, 0, 0, 0, 1, 0, 1, 2;
 
-  Eigen::ArrayXd alpha = Eigen::ArrayXd::Zero(1);
   Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(3);
 
-  alpha[0] = 0.01;
+  double alpha = 0.01;
   lambda << 2.0, 1.8, 1.0;
 
   slope::Slope model;
@@ -51,21 +50,21 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     model.setMaxIt(25);
     model.setSolver("hybrid");
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.fit(x, y, alpha, lambda);
 
-    auto dual_gaps = model.getDualGaps().front();
+    auto dual_gaps = fit.getGaps();
 
     REQUIRE(dual_gaps.front() >= 0);
     REQUIRE(dual_gaps.back() <= 1e-6);
 
-    Eigen::VectorXd coefs_hybrid = model.getCoefs().front();
+    Eigen::VectorXd coefs_hybrid = fit.getCoefs();
 
     model.setMaxIt(2000);
     model.setSolver("pgd");
-    model.fit(x, y, alpha, lambda);
-    Eigen::VectorXd coefs_pgd = model.getCoefs().front();
+    fit = model.fit(x, y, alpha, lambda);
+    Eigen::VectorXd coefs_pgd = fit.getCoefs();
 
-    auto dual_gaps_pgd = model.getDualGaps().front();
+    auto dual_gaps_pgd = fit.getGaps();
 
     REQUIRE(dual_gaps_pgd.front() >= 0);
     REQUIRE(dual_gaps_pgd.back() <= 1e-6);
@@ -85,21 +84,21 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     model.setMaxIt(25);
     model.setSolver("hybrid");
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.fit(x, y, alpha, lambda);
 
-    Eigen::VectorXd coefs_hybrid = model.getCoefs().front();
-    double intercept_hybrid = model.getIntercepts()[0][0];
+    Eigen::VectorXd coefs_hybrid = fit.getCoefs();
+    double intercept_hybrid = fit.getIntercepts()[0];
 
-    auto dual_gaps_hybrid = model.getDualGaps().front();
+    auto dual_gaps_hybrid = fit.getGaps();
 
     REQUIRE(dual_gaps_hybrid.front() >= 0);
     REQUIRE(dual_gaps_hybrid.back() <= 1e-6);
 
     model.setMaxIt(1e4);
     model.setSolver("pgd");
-    model.fit(x, y, alpha, lambda);
-    Eigen::VectorXd coefs_pgd = model.getCoefs().front();
-    double intercept_pgd = model.getIntercepts()[0][0];
+    fit = model.fit(x, y, alpha, lambda);
+    Eigen::VectorXd coefs_pgd = fit.getCoefs();
+    double intercept_pgd = fit.getIntercepts()[0];
 
     REQUIRE_THAT(coefs_hybrid, VectorApproxEqual(coefs_ref, 1e-4));
     REQUIRE_THAT(coefs_pgd, VectorApproxEqual(coefs_ref, 1e-4));
@@ -116,16 +115,16 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     model.setMaxIt(25);
     model.setSolver("hybrid");
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.fit(x, y, alpha, lambda);
 
-    Eigen::VectorXd coefs = model.getCoefs().front();
-    double intercept = model.getIntercepts()[0][0];
+    Eigen::VectorXd coefs = fit.getCoefs();
+    double intercept = fit.getIntercepts()[0];
 
     model.setMaxIt(1e4);
     model.setSolver("pgd");
-    model.fit(x, y, alpha, lambda);
-    Eigen::VectorXd coefs_pgd = model.getCoefs().front();
-    double intercept_pgd = model.getIntercepts()[0][0];
+    fit = model.fit(x, y, alpha, lambda);
+    Eigen::VectorXd coefs_pgd = fit.getCoefs();
+    double intercept_pgd = fit.getIntercepts()[0];
 
     REQUIRE_THAT(coefs, VectorApproxEqual(coefs_ref, 1e-4));
     REQUIRE_THAT(coefs_pgd, VectorApproxEqual(coefs_ref, 1e-4));
@@ -136,11 +135,10 @@ TEST_CASE("Poisson models", "[models][poisson]")
   SECTION("Lasso penalty, no intercept")
   {
 
-    Eigen::ArrayXd alpha = Eigen::ArrayXd::Zero(1);
+    double alpha = 0.1;
     Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(3);
 
     lambda << 1.0, 1.0, 1.0;
-    alpha[0] = 0.1;
 
     model.setStandardize(false);
     model.setIntercept(false);
@@ -149,19 +147,19 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     model.setMaxIt(25);
     model.setSolver("hybrid");
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.fit(x, y, alpha, lambda);
 
-    Eigen::VectorXd coefs_hybrid = model.getCoefs().front();
+    Eigen::VectorXd coefs_hybrid = fit.getCoefs();
 
-    auto dual_gaps_hybrid = model.getDualGaps().front();
+    auto dual_gaps_hybrid = fit.getGaps();
 
     REQUIRE(dual_gaps_hybrid.front() >= 0);
     REQUIRE(dual_gaps_hybrid.back() <= 1e-6);
 
     model.setMaxIt(20000);
     model.setSolver("pgd");
-    model.fit(x, y, alpha, lambda);
-    Eigen::VectorXd coefs_pgd = model.getCoefs().front();
+    fit = model.fit(x, y, alpha, lambda);
+    Eigen::VectorXd coefs_pgd = fit.getCoefs();
 
     REQUIRE_THAT(coefs_hybrid, VectorApproxEqual(coefs_ref, 1e-4));
     REQUIRE_THAT(coefs_pgd, VectorApproxEqual(coefs_ref, 1e-4));
@@ -170,11 +168,10 @@ TEST_CASE("Poisson models", "[models][poisson]")
   SECTION("Lasso penalty, with intercept")
   {
 
-    Eigen::ArrayXd alpha = Eigen::ArrayXd::Zero(1);
     Eigen::ArrayXd lambda = Eigen::ArrayXd::Zero(3);
 
     lambda << 1.0, 1.0, 1.0;
-    alpha[0] = 0.1;
+    double alpha = 0.1;
 
     model.setStandardize(false);
     model.setIntercept(true);
@@ -183,21 +180,21 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     model.setMaxIt(50);
     model.setSolver("hybrid");
-    model.fit(x, y, alpha, lambda);
+    auto fit = model.fit(x, y, alpha, lambda);
 
-    Eigen::VectorXd coefs_hybrid = model.getCoefs().front();
-    double intercept_hybrid = model.getIntercepts()[0][0];
+    Eigen::VectorXd coefs_hybrid = fit.getCoefs();
+    double intercept_hybrid = fit.getIntercepts()[0];
 
-    auto dual_gaps_hybrid = model.getDualGaps().front();
+    auto dual_gaps_hybrid = fit.getGaps();
 
     REQUIRE(dual_gaps_hybrid.front() >= 0);
     REQUIRE(dual_gaps_hybrid.back() <= 1e-6);
 
     model.setMaxIt(50000);
     model.setSolver("pgd");
-    model.fit(x, y, alpha, lambda);
-    Eigen::VectorXd coefs_pgd = model.getCoefs().front();
-    double intercept_pgd = model.getIntercepts()[0][0];
+    fit = model.fit(x, y, alpha, lambda);
+    Eigen::VectorXd coefs_pgd = fit.getCoefs();
+    double intercept_pgd = fit.getIntercepts()[0];
 
     REQUIRE_THAT(coefs_hybrid, VectorApproxEqual(coefs_ref, 1e-4));
     REQUIRE_THAT(intercept_hybrid, WithinRel(-0.39652440, 1e-4));

--- a/tests/printing.cpp
+++ b/tests/printing.cpp
@@ -29,5 +29,5 @@ TEST_CASE("Printing", "[path][gaussian]")
 
   model.setPrintLevel(3);
 
-  REQUIRE_NOTHROW(model.fit(x, y));
+  REQUIRE_NOTHROW(model.path(x, y));
 }

--- a/tests/screening.cpp
+++ b/tests/screening.cpp
@@ -76,12 +76,12 @@ TEST_CASE("Strong screening rule", "[screening]")
     slope::Slope model;
 
     model.setScreening("none");
-    model.fit(data.x, data.y);
-    Eigen::VectorXd coefs = model.getCoefs().back();
+    auto fit = model.path(data.x, data.y);
+    Eigen::VectorXd coefs = fit.getCoefs().back();
 
     model.setScreening("strong");
-    model.fit(data.x, data.y);
-    Eigen::VectorXd coefs_screen = model.getCoefs().back();
+    fit = model.path(data.x, data.y);
+    Eigen::VectorXd coefs_screen = fit.getCoefs().back();
 
     REQUIRE_THAT(coefs, VectorApproxEqual(coefs_screen, 1e-4));
   }
@@ -94,8 +94,8 @@ TEST_CASE("Screening benchmarks", "[!benchmark]")
   slope::Slope model;
 
   model.setIntercept(false);
-  model.fit(data.x, data.y);
-  Eigen::VectorXd coefs = model.getCoefs().back();
+  auto fit = model.path(data.x, data.y);
+  Eigen::VectorXd coefs = fit.getCoefs().back();
 
   BENCHMARK("No screening")
   {

--- a/tests/sparse.cpp
+++ b/tests/sparse.cpp
@@ -48,11 +48,11 @@ TEST_CASE("Sparse and dense methods agree", "[gaussian][sparse]")
   model.setIntercept(false);
   model.setStandardize(true);
 
-  model.fit(x_sparse, y, alpha, lambda);
-  auto coefs_sparse = model.getCoefs();
+  auto fit = model.path(x_sparse, y, alpha, lambda);
+  auto coefs_sparse = fit.getCoefs();
 
-  model.fit(x_dense, y, alpha, lambda);
-  auto coefs_dense = model.getCoefs();
+  fit = model.path(x_dense, y, alpha, lambda);
+  auto coefs_dense = fit.getCoefs();
 
   Eigen::VectorXd coef_sparse = coefs_sparse.front();
   Eigen::VectorXd coef_dense = coefs_dense.front();


### PR DESCRIPTION
`path()` returns the full path (what `fit()` used to do), and `fit()`
now just returns the model for a single alpha value. Internally, `fit()`
just calls `path()` but post processes the output by some simple
operations. It's unlikely that there will be any point in creating some
function `fit()` that we can call internally as well, given the
discussion in #61.

Closes #61.