### PR TITLE
feat!: allow user-specified scales and centers

### DIFF
--- a/src/slope/math.h
+++ b/src/slope/math.h
@@ -131,7 +131,7 @@ softmax(const Eigen::MatrixXd& x);
  * @param residual The residual vector.
  * @param x_centers The vector of center values for each column of x.
  * @param x_scales The vector of scale values for each column of x.
- * @param standardize Flag indicating whether to standardize the gradient.
+ * @param normalize_jit Flag indicating whether to standardize the gradient.
  * @return The computed gradient vector.
  */
 template<typename T>

--- a/src/slope/normalize.h
+++ b/src/slope/normalize.h
@@ -1,5 +1,6 @@
 /** @file
- * @brief Functions to standardize the design matrix and rescale coefficients
+ * @brief Functions to normalize the design matrix and rescale coefficients
+ * in case the design was normalized
  */
 
 #pragma once
@@ -16,18 +17,17 @@ namespace slope {
  *
  * @tparam T The type of the input matrix.
  * @param x The input matrix.
+ * @param x_centers A vector where the computed means will be stored.
+ * @param x_scales A vector where the computed standard deviations will be
+ * stored.
  * @return A tuple containing the means and standard deviations of the columns.
  */
 template<typename T>
-std::tuple<Eigen::VectorXd, Eigen::VectorXd>
-computeCentersAndScales(const T& x)
+void
+standardize(const T& x, Eigen::VectorXd& x_centers, Eigen::VectorXd& x_scales)
 {
-  // TODO: Make this function more general and allow other statistics.
   const int n = x.rows();
   const int p = x.cols();
-
-  Eigen::VectorXd x_means(p);
-  Eigen::VectorXd x_stddevs(p);
 
   for (int j = 0; j < p; ++j) {
     double mean = 0.0;
@@ -51,49 +51,151 @@ computeCentersAndScales(const T& x)
       m2 += delta * delta2;
     }
 
-    x_means(j) = mean;
-    x_stddevs(j) = std::sqrt(m2 / n);
+    x_centers(j) = mean;
+    x_scales(j) = std::sqrt(m2 / n);
   }
-  return { x_means, x_stddevs };
+}
+
+/**
+ * Compute centers and scales for the columns of the input matrix.
+ *
+ * There are three supported normalization types:
+ * - "none": Do not compute centers and scales.
+ * - "manual": Use the provided centers and scales. If one is missing, a default
+ *   of zeros for centers or ones for scales will be used.
+ * - "standardization": Compute centers and scales using Welford’s algorithm.
+ *
+ * @tparam T The type of the input matrix.
+ * @param x The input matrix.
+ * @param x_centers A vector where the computed or provided centers will be
+ * stored.
+ * @param x_scales A vector where the computed or provided scales will be
+ * stored.
+ * @param type A string specifying the normalization type ("none", "manual", or
+ * "standardization").
+ *
+ * @throws std::invalid_argument if the provided manual centers or scales have
+ * invalid dimensions or contain non-finite values.
+ */
+template<typename T>
+void
+computeCentersAndScales(const T& x,
+                        Eigen::VectorXd& x_centers,
+                        Eigen::VectorXd& x_scales,
+                        const std::string& type)
+{
+  int p = x.cols();
+
+  if (type != "none" && type != "manual") {
+    x_centers.resize(p);
+    x_scales.resize(p);
+  }
+
+  if (type == "none") {
+  } else if (type == "manual") {
+    // Manual centers and scales provided, just check that they are valid
+
+    // TODO: Right now we force both centers and scales to be present, but we
+    // should allow for only specifying one or the other, which is also what
+    // some types of normalization (max-abs) are defined as.
+    if (x_centers.size() == 0) {
+      x_centers = Eigen::VectorXd::Zero(p);
+    }
+
+    if (x_scales.size() == 0) {
+      x_centers = Eigen::VectorXd::Ones(p);
+    }
+
+    if (x_centers.size() != p) {
+      throw std::invalid_argument("Invalid dimensions in centers");
+    }
+
+    if (x_scales.size() != p) {
+      throw std::invalid_argument("Invalid dimensions in scales");
+    }
+
+    if (!x_centers.allFinite()) {
+      throw std::invalid_argument("Centers must be finite");
+    }
+
+    if (!x_scales.allFinite()) {
+      throw std::invalid_argument("Scales must be finite");
+    }
+
+  } else if (type == "standardization") {
+    standardize(x, x_centers, x_scales);
+  } else {
+    throw std::invalid_argument("Invalid normalization type");
+  }
 }
 
 /**
  * Normalize a dense matrix by centering and scaling.
  *
- * @param x The dense input matrix.
- * @param x_centers The locations of the columns.
- * @param x_scales The scales of the columns.
+ * The function computes column centers and scaling factors based on the
+ * specified normalization type ("none", "manual", or "standardization"). If
+ * modify_x is true, the normalization is applied directly to the input matrix.
+ *
+ * @param x         The dense input matrix to be normalized.
+ * @param x_centers A vector that will hold the column centers. It will be
+ *                  resized to match the number of columns.
+ * @param x_scales  A vector that will hold the column scaling factors. It will
+ *                  be resized to match the number of columns.
+ * @param type      A string specifying the normalization type ("none",
+ *                  "manual", or "standardization").
+ * @param modify_x  If true, modifies x in-place; otherwise, x remains unchanged
+ *                  (centers/scales are still computed).
+ *
+ * @return true if normalization succeeds, false otherwise.
  */
-void
+bool
 normalize(Eigen::MatrixXd& x,
-          const Eigen::VectorXd& x_centers,
-          const Eigen::VectorXd& x_scales);
+          Eigen::VectorXd& x_centers,
+          Eigen::VectorXd& x_scales,
+          const std::string& type,
+          const bool modify_x);
 
 /**
- * Normalize a sparse matrix (without centering to preserve sparsity).
+ * Normalize a sparse matrix by scaling only.
  *
- * @param x The sparse input matrix.
- * @param x_centers The locations of the columns.
- * @param x_scales The scales of the columns.
+ * To preserve sparsity, centering is not applied. The scaling factors for each
+ * column are computed according to the specified normalization type ("none",
+ * "manual", or "standardization"). If modify_x is true, the scaling is applied
+ * directly to the input matrix.
+ *
+ * @param x The sparse input matrix to be normalized.
+ * @param x_centers A vector that will hold the column centers.
+ * For sparse matrices, centering is typically skipped; this
+ * parameter is maintained for consistency.
+ * @param x_scales  A vector that will hold the column scaling factors. It will
+ * be resized to match the number of columns.
+ * @param type A string specifying the normalization type ("none",
+ * "manual", or "standardization").
+ * @param modify_x If true, performs in-place scaling on x; otherwise, leaves x
+ * unchanged.
+ *
+ * @return true if normalization succeeds, false otherwise.
  */
-void
+bool
 normalize(Eigen::SparseMatrix<double>& x,
-          const Eigen::VectorXd& x_centers,
-          const Eigen::VectorXd& x_scales);
+          Eigen::VectorXd& x_centers,
+          Eigen::VectorXd& x_scales,
+          const std::string& type,
+          const bool modify_x);
 
 /**
  * @brief Rescales the coefficients using the given parameters.
  *
  * This function rescales the coefficients by dividing each coefficient by the
- * corresponding scale factor and subtracting the product of the center and the
- * coefficient from the intercept.
+ * corresponding scale factor and subtracting the product of the center and
+ * the coefficient from the intercept.
  *
  * @param beta0 The intercept coefficient.
  * @param beta The vector of coefficients.
  * @param x_centers The vector of center values.
  * @param x_scales The vector of scale factors.
  * @param intercept Should an intercept be fit?
- * @param standardize Is the design matrix standardized?
+ * @param normalization_type type of normalization
  * @return A tuple containing the rescaled intercept and coefficients.
  *
  * @note The input vectors `beta`, `x_centers`, and `x_scales` must have the
@@ -108,6 +210,6 @@ rescaleCoefficients(Eigen::VectorXd beta0,
                     const Eigen::VectorXd& x_centers,
                     const Eigen::VectorXd& x_scales,
                     const bool intercept,
-                    const bool standardize);
+                    const std::string& normalization_type);
 
 } // namespace slope

--- a/tests/binomial.cpp
+++ b/tests/binomial.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Binomial, simple fixed design", "[binomial][basic]")
 
   SECTION("No intercept, no standardization")
   {
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(false);
 
     Eigen::Vector3d coef_target;
@@ -87,7 +87,7 @@ TEST_CASE("Binomial, simple fixed design", "[binomial][basic]")
   SECTION("Intercept, no standardization")
   {
     model.setIntercept(true);
-    model.setStandardize(false);
+    model.setNormalization("none");
 
     std::vector<double> coef_target = { 1.2748806, 0.0, 0.2062611 };
     double intercept_target = 0.3184528;

--- a/tests/gaussian.cpp
+++ b/tests/gaussian.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Simple low-dimensional design", "[gaussian][basic]")
   slope::SlopeFit fit;
 
   model.setIntercept(false);
-  model.setStandardize(false);
+  model.setNormalization("none");
 
   fit = model.fit(x, y, alpha, lambda);
 
@@ -59,7 +59,7 @@ TEST_CASE("X is identity", "[gaussian][identity]")
 
   slope::Slope model;
   model.setIntercept(false);
-  model.setStandardize(false);
+  model.setNormalization("none");
   auto fit = model.fit(x, y, alpha, lambda);
 
   double gap = fit.getGaps().back();
@@ -135,7 +135,7 @@ TEST_CASE("Gaussian models", "[gaussian]")
 
   SECTION("No intercept, no standardization")
   {
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(false);
 
     coef_target << 0.6864545, -0.6864545, 0.0000000;
@@ -159,8 +159,9 @@ TEST_CASE("Gaussian models", "[gaussian]")
 
   SECTION("No intercept, with standardization")
   {
-    model.setStandardize(true);
+    model.setNormalization("standardization");
     model.setIntercept(false);
+    // model.setModifyX(true);
 
     coef_target << 0.700657772, -0.730587233, 0.008997323;
 
@@ -178,7 +179,7 @@ TEST_CASE("Gaussian models", "[gaussian]")
 
   SECTION("With intercept, with standardization")
   {
-    model.setStandardize(true);
+    model.setNormalization("standardization");
     model.setIntercept(true);
 
     coef_target << 0.700657772, -0.730587234, 0.008997323;
@@ -203,7 +204,7 @@ TEST_CASE("Gaussian models", "[gaussian]")
 
   SECTION("With intercept, no standardization")
   {
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(true);
     model.setMaxIt(1e5);
 

--- a/tests/multinomial.cpp
+++ b/tests/multinomial.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Multinomial objective: unpenalized", "[objective][multinomial]")
 
     // Fit the model
     model.setIntercept(false);
-    model.setStandardize(false);
+    model.setNormalization("none");
 
     double alpha = 0;
     lambda << 6.0, 5.0, 4.0, 3.0, 2.0, 1.0;

--- a/tests/poisson.cpp
+++ b/tests/poisson.cpp
@@ -45,7 +45,7 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
   SECTION("No intercept, no standardization")
   {
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(false);
 
     model.setMaxIt(25);
@@ -77,7 +77,7 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
   SECTION("With intercept, no standardization")
   {
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(true);
 
     coefs_ref << 0.3925911, -0.2360691, 0.4464808;
@@ -108,7 +108,7 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
   SECTION("With intercept, with standardization")
   {
-    model.setStandardize(true);
+    model.setNormalization("standardization");
     model.setIntercept(true);
 
     coefs_ref << 0.4017805, -0.2396130, 0.4600816;
@@ -140,7 +140,7 @@ TEST_CASE("Poisson models", "[models][poisson]")
 
     lambda << 1.0, 1.0, 1.0;
 
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(false);
 
     coefs_ref << 0.010928758, 0.0, 0.007616257;
@@ -173,7 +173,7 @@ TEST_CASE("Poisson models", "[models][poisson]")
     lambda << 1.0, 1.0, 1.0;
     double alpha = 0.1;
 
-    model.setStandardize(false);
+    model.setNormalization("none");
     model.setIntercept(true);
 
     coefs_ref << 0.05533582, 0.0, 0.15185182;


### PR DESCRIPTION
Closes #37. We need to revisit this later on, because really we should have separate scale_jit and center_jit settings, so that we can allow for any combination of scaling and centering without incurring additional costs.