### PR TITLE
feat: parallelize gradient computations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if(BUILD_TESTING)
   add_executable(
     tests
     tests/assertions.cpp
+    tests/benchmarks.cpp
     tests/generate_data.cpp
     tests/lambda_sequence.cpp
     tests/load_data.cpp

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -57,7 +57,6 @@ tasks:
       - ctest --test-dir {{.BUILD_DIR}} --output-on-failure
 
   benchmark:
+    deps: [build]
     cmds:
-      - cmake -B {{.BUILD_DIR}} -S . -DBUILD_DOCS=OFF -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release
-      - cmake --build {{.BUILD_DIR}}
       - ./build/tests [!benchmark]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 ignore:
-  - "tests/test_helpers.hpp"
+  - "tests/test_helpers.cpp"
+  - "tests/benchmarks.cpp"

--- a/src/slope/math.h
+++ b/src/slope/math.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "slope/normalize.h"
+#include "threads.h"
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
 #include <numeric>
@@ -248,7 +249,11 @@ updateGradient(Eigen::MatrixXd& gradient,
     weighted_residual.col(k) = residual.col(k).cwiseProduct(w);
     double wr_sum = weighted_residual.col(k).sum();
 
-    for (const auto& j : active_set) {
+#ifdef _OPENMP
+#pragma omp parallel for num_threads(Threads::get())
+#endif
+    for (size_t i = 0; i < active_set.size(); ++i) {
+      const int j = active_set[i];
       switch (jit_normalization) {
         case JitNormalization::Both:
           gradient(j, k) =

--- a/src/slope/threads.h
+++ b/src/slope/threads.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <algorithm>
+#include <stdexcept>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+namespace slope {
+
+/**
+ * @brief Manages OpenMP thread settings across libslope
+ *
+ * This class provides a centralized way to control thread settings for parallel
+ * computations. It handles both OpenMP and non-OpenMP builds, defaulting to
+ * sequential execution when OpenMP is not available.
+ *
+ * Thread count defaults to half of the available threads (typically the number
+ * of physical CPU cores) to avoid performance degradation from hyperthreading
+ * when using Eigen.
+ *
+ * Usage:
+ * @code
+ * Threads::set(4);  // Set to use 4 threads
+ * int n = Threads::get();  // Get current thread count
+ * @endcode
+ */
+class Threads
+{
+public:
+  /**
+   * @brief Set the number of threads to use for parallel computations
+   *
+   * @param n Number of threads. Must be positive.
+   */
+  static void set(const int n)
+  {
+    if (n > 0) {
+      num_threads = n;
+#ifdef _OPENMP
+      omp_set_num_threads(n);
+#endif
+    } else {
+      throw std::invalid_argument("Number of threads must be positive");
+    }
+  }
+
+  /**
+   * @brief Get the current number of threads
+   *
+   * @return Current thread count
+   */
+  static int get() { return num_threads; }
+
+private:
+#ifdef _OPENMP
+  /// Number of threads to use. Defaults to half of max threads (physical cores)
+  inline static int num_threads = std::max(1, omp_get_max_threads() / 2);
+#else
+  /// Default to single thread when OpenMP is not available
+  inline static int num_threads = 1;
+#endif
+};
+
+} // namespace slope

--- a/tests/assertions.cpp
+++ b/tests/assertions.cpp
@@ -1,4 +1,5 @@
 #include "../src/slope/slope.h"
+#include "slope/threads.h"
 #include "test_helpers.hpp"
 #include <Eigen/Core>
 #include <catch2/catch_test_macros.hpp>
@@ -59,5 +60,10 @@ TEST_CASE("Assertions", "[assertions]")
                       std::invalid_argument);
     REQUIRE_THROWS_AS(model.setOscarParameters(1.0, -2.0),
                       std::invalid_argument);
+  }
+
+  SECTION("Threads")
+  {
+    REQUIRE_THROWS_AS(slope::Threads::set(-1), std::invalid_argument);
   }
 }

--- a/tests/benchmarks.cpp
+++ b/tests/benchmarks.cpp
@@ -1,0 +1,54 @@
+#include "../src/slope/math.h"
+#include "../src/slope/threads.h"
+#include "generate_data.hpp"
+#include "test_helpers.hpp"
+#include <Eigen/Core>
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <cmath>
+
+TEST_CASE("Parallelized gradient computations", "[!benchmark]")
+{
+  int n = 1000;
+  int p = 1000;
+  int m = 1;
+
+  Eigen::MatrixXd gradient(p, m);
+  std::vector<int> active_set(p);
+  Eigen::VectorXd x_centers(p);
+  Eigen::VectorXd x_scales(p);
+  Eigen::VectorXd w(n);
+  slope::JitNormalization jit_normalization = slope::JitNormalization::Both;
+
+  auto data = generateData(n, p);
+
+  auto x = data.x;
+  auto residual = data.y;
+
+  BENCHMARK("Gradient sequential")
+  {
+    slope::Threads::set(1);
+    slope::updateGradient(gradient,
+                          x,
+                          residual,
+                          active_set,
+                          x_centers,
+                          x_scales,
+                          w,
+                          jit_normalization);
+  };
+
+  BENCHMARK("Gradient parallel")
+  {
+    slope::Threads::set(4);
+    slope::updateGradient(gradient,
+                          x,
+                          residual,
+                          active_set,
+                          x_centers,
+                          x_scales,
+                          w,
+                          jit_normalization);
+  };
+}


### PR DESCRIPTION
Add a `Threads` class with methods `set` and `get` to parallelize
computations. This commit only parallelizes gradient computations via
`updateGradient()` but this can easily be extended in the future.