### PR TITLE
feat: add prediction method to `SlopeFit`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ if(BUILD_TESTING)
     tests/normalization.cpp
     tests/path.cpp
     tests/poisson.cpp
+    tests/predictions.cpp
     tests/prox.cpp
     tests/qnorm.cpp
     tests/quadratic.cpp

--- a/src/slope/slope.h
+++ b/src/slope/slope.h
@@ -263,7 +263,7 @@ public:
    * @param alpha Sequence of mixing parameters for elastic net regularization
    * @param lambda Sequence of regularization parameters (if empty, computed
    * automatically)
-   * @return SlopePath Object containing full solution path and optimization
+   * @return SlopePath object containing full solution path and optimization
    * metrics
    *
    * Fits SLOPE models for each combination of alpha and lambda values, storing

--- a/src/slope/slope_fit.h
+++ b/src/slope/slope_fit.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "slope/losses/setup_loss.h"
+#include "slope/normalize.h"
 #include <Eigen/Dense>
 #include <Eigen/SparseCore>
+#include <memory>
 
 namespace slope {
 
@@ -27,6 +30,9 @@ private:
     duals; ///< History of dual objective values during optimization
   std::vector<double> time; ///< Time points during optimization
   int passes; ///< Number of passes through the data during optimization
+  std::string centering_type; ///< Type of centering
+  std::string scaling_type;   ///< Type of scaling
+  std::string loss_type;      ///< Loss type
 
 public:
   /// Default constructor
@@ -45,17 +51,22 @@ public:
    * @param duals History of dual objectives
    * @param time Vector of optimization timestamps
    * @param passes Number of optimization passes
+   * @param centering_type Type of centering for the design matrix
+   * @param scaling_type Type of scaling for the design matrix
+   *
    */
   SlopeFit(const Eigen::VectorXd& intercepts,
            const Eigen::SparseMatrix<double>& coefs,
            const double alpha,
            const Eigen::ArrayXd& lambda,
-           double deviance,
-           double null_deviance,
+           const double deviance,
+           const double null_deviance,
            const std::vector<double>& primals,
            const std::vector<double>& duals,
            const std::vector<double>& time,
-           const int passes)
+           const int passes,
+           const std::string& centering_type,
+           const std::string& scaling_type)
     : intercepts{ intercepts }
     , coefs{ coefs }
     , alpha{ alpha }
@@ -66,6 +77,8 @@ public:
     , duals{ duals }
     , time{ time }
     , passes{ passes }
+    , centering_type{ centering_type }
+    , scaling_type{ scaling_type }
   {
   }
 
@@ -125,7 +138,7 @@ public:
    * @return double The deviance ratio, a measure of model fit (higher is
    * better)
    */
-  double getDevianceRatios() const { return 1.0 - deviance / null_deviance; }
+  double getDevianceRatio() const { return 1.0 - deviance / null_deviance; }
 
   /**
    * @brief Calculate the duality gaps during optimization
@@ -140,6 +153,40 @@ public:
       gaps[i] = primals[i] - duals[i];
     }
     return gaps;
+  }
+
+  /**
+   * @brief Predict the response for a given input matrix
+   * @return Matrix of predicted responses
+   * @see Loss
+   */
+  template<typename T>
+  Eigen::MatrixXd predict(T& x) const
+  {
+    int n = x.rows();
+    int m = coefs.cols();
+
+    std::unique_ptr<Loss> loss = setupLoss(this->loss_type);
+
+    Eigen::VectorXd x_centers;
+    Eigen::VectorXd x_scales;
+    normalize(
+      x, x_centers, x_scales, this->centering_type, this->scaling_type, false);
+
+    Eigen::MatrixXd eta = Eigen::MatrixXd::Zero(n, m);
+
+    for (int k = 0; k < m; ++k) {
+      for (typename Eigen::SparseMatrix<double>::InnerIterator it(coefs, k); it;
+           ++it) {
+        int j = it.row();
+        eta.col(k) += x.col(j) * (it.value() / x_scales(j));
+        eta.col(k).array() -= it.value() * x_centers(j) / x_scales(j);
+      }
+
+      eta.col(k).array() += intercepts(k);
+    }
+
+    return loss->predict(eta);
   }
 };
 

--- a/tests/predictions.cpp
+++ b/tests/predictions.cpp
@@ -1,0 +1,26 @@
+#include "generate_data.hpp"
+#include "test_helpers.hpp"
+#include <Eigen/Core>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <slope/slope.h>
+
+TEST_CASE("Predictions", "[predict]")
+{
+  using namespace Catch::Matchers;
+
+  auto data = generateData(100, 10);
+
+  slope::Slope model;
+
+  auto path = model.path(data.x, data.y);
+
+  auto fit = path(5);
+
+  auto new_data = generateData(20, 10);
+
+  auto pred = fit.predict(new_data.x);
+
+  REQUIRE(pred.rows() == 20);
+}


### PR DESCRIPTION
Adds a prediction method for `SlopFit` objects.

refactor: make `SlopePath` consist of a vector of `SlopeFit` objects
instead of several different vectors.