### PR TITLE
fix: handle exceptions in openmp regions

### DIFF
--- a/tests/cv.cpp
+++ b/tests/cv.cpp
@@ -154,7 +154,7 @@ TEST_CASE("Repeated cross-validation", "[cv]")
           cv_config.n_repeats * cv_config.n_folds);
 }
 
-TEST_CASE("Cross-validation: user folds", "[cv][user_folds]")
+TEST_CASE("Cross-validation: user folds", "[cv]")
 {
   using Catch::Matchers::WithinAbs;
 
@@ -168,10 +168,33 @@ TEST_CASE("Cross-validation: user folds", "[cv][user_folds]")
     { { 0, 2, 4 }, { 1, 5, 8 }, { 7, 6, 3 } },
     { { 2, 0, 3 }, { 6, 5, 1 }, { 7, 1, 8 } }
   };
+
   cv_config.hyperparams["q"] = { 0.1, 0.2 };
   cv_config.predefined_folds = user_folds;
 
   auto res = crossValidate(model, data.x, data.y, cv_config);
 
   REQUIRE(res.results.front().score.rows() == 6);
+}
+
+TEST_CASE("Cross-validation: user folds", "[cv][user_folds]")
+{
+  using Catch::Matchers::WithinAbs;
+
+  slope::Slope model;
+  int n = 9;
+
+  auto cv_config = slope::CvConfig();
+  auto data = generateData(n, 2, "quadratic", 1, 0.15, 0.2, 1);
+
+  std::vector<std::vector<std::vector<int>>> user_folds = {
+    { { 0, 2, 4 }, { 1, 5, 8 }, { 7, 6, 3 } },
+    { { 2, 0, 3 }, { 6, 5, 1 }, { 7, 1, 8 } }
+  };
+
+  cv_config.hyperparams["q"] = { 0.1, 0.2 };
+  cv_config.predefined_folds = user_folds;
+
+  REQUIRE_THROWS_AS(crossValidate(model, data.x, data.y, cv_config),
+                    std::runtime_error);
 }


### PR DESCRIPTION
Fixes #105. Hopefully these exceptions will propagate properly when interfaced through Rcpp. Wasn't sure if it ought to be `std::runtime_error` or `std::exception` when throwing at the end of the parallel region.