### PR TITLE
refactor: move cluster object into hybrid solver

### DIFF
--- a/src/slope/slope.h
+++ b/src/slope/slope.h
@@ -38,8 +38,9 @@ public:
     , modify_x(false)
     , update_clusters(false)
     , collect_diagnostics(false)
-    , alpha_min_ratio(-1)
-    , dev_change_tol(1e-5) // TODO: Use std::optional for alpha_min_ratio
+    , return_clusters(false)
+    , alpha_min_ratio(-1) // TODO: Use std::optional for alpha_min_ratio
+    , dev_change_tol(1e-5)
     , dev_ratio_tol(0.999)
     , learning_rate_decr(0.5)
     , q(0.1)
@@ -90,6 +91,14 @@ public:
    * clusters updated.
    */
   void setUpdateClusters(bool update_clusters);
+
+  /**
+   * @brief Sets the update clusters flag.
+   *
+   * @param return_clusters Selects whether the fitted model should return
+   * cluster information.
+   */
+  void setReturnClusters(const bool return_clusters);
 
   /**
    * @brief Sets the alpha min ratio.
@@ -308,6 +317,7 @@ private:
   bool modify_x;
   bool update_clusters;
   bool collect_diagnostics;
+  bool return_clusters;
   double alpha_min_ratio;
   double dev_change_tol;
   double dev_ratio_tol;

--- a/src/slope/slope_fit.h
+++ b/src/slope/slope_fit.h
@@ -14,14 +14,17 @@ namespace slope {
  * Estimation) fitting.
  *
  * This class stores the results of a SLOPE regression, including coefficients,
- * intercepts, regularization parameters, and optimization metrics.
+ * intercepts, clusters (if required), regularization parameters, and
+ * optimization metrics.
  */
 class SlopeFit
 {
 private:
   Eigen::VectorXd intercepts;        ///< Vector of intercept terms
   Eigen::SparseMatrix<double> coefs; ///< Sparse matrix of fitted coefficients
-  double alpha;                      ///< Scaling of lambda sequence
+  std::vector<std::vector<int>>
+    clusters;            ///< Indices of coefficients in each cluster
+  double alpha;          ///< Scaling of lambda sequence
   Eigen::ArrayXd lambda; ///< Regularization weights for the sorted L1 norm
   double deviance;       ///< Final model deviance
   double null_deviance;  ///< Null (or intercept-only) model deviance
@@ -44,6 +47,7 @@ public:
    *
    * @param intercepts Vector of intercept terms
    * @param coefs Matrix of fitted coefficients
+   * @param clusters Clusters of coefficients
    * @param alpha Mixing parameter between L1 and SLOPE norms
    * @param lambda Sequence of decreasing weights
    * @param deviance Final model deviance
@@ -58,6 +62,7 @@ public:
    */
   SlopeFit(const Eigen::VectorXd& intercepts,
            const Eigen::SparseMatrix<double>& coefs,
+           const std::vector<std::vector<int>>& clusters,
            const double alpha,
            const Eigen::ArrayXd& lambda,
            const double deviance,
@@ -70,6 +75,7 @@ public:
            const std::string& scaling_type)
     : intercepts{ intercepts }
     , coefs{ coefs }
+    , clusters{ clusters }
     , alpha{ alpha }
     , lambda{ lambda }
     , deviance{ deviance }
@@ -92,6 +98,11 @@ public:
    * @brief Gets the sparse coefficient matrix for this fit
    */
   const Eigen::SparseMatrix<double>& getCoefs() const { return coefs; }
+
+  /**
+   * @brief Gets the clusters
+   */
+  const std::vector<std::vector<int>>& getClusters() const { return clusters; }
 
   /**
    * @brief Gets the lambda (regularization) parameter used

--- a/src/slope/slope_path.h
+++ b/src/slope/slope_path.h
@@ -104,6 +104,26 @@ public:
   }
 
   /**
+   * @brief Returns the clusters for each solution in the path.
+   *
+   * @return std::vector<std::vector<std::vector<int>>> Reference to the
+   * vector of clusters
+   *
+   * Each element in the returned vector is a sparse matrix containing the model
+   * coefficients for a particular solution in the regularization path.
+   */
+  std::vector<std::vector<std::vector<int>>> getClusters() const
+  {
+    std::vector<std::vector<std::vector<int>>> clusters;
+
+    for (const auto& fit : fits) {
+      clusters.emplace_back(fit.getClusters());
+    }
+
+    return clusters;
+  }
+
+  /**
    * @brief Gets the sparse coefficient matrix for a specific solution in the
    * path
    *

--- a/src/slope/solvers/hybrid.cpp
+++ b/src/slope/solvers/hybrid.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "hybrid.h"
-#include "../clusters.h"
 #include "../losses/loss.h"
 #include "../sorted_l1_norm.h"
 #include <Eigen/Dense>
@@ -19,7 +18,6 @@ void
 Hybrid::run(Eigen::VectorXd& beta0,
             Eigen::VectorXd& beta,
             Eigen::MatrixXd& eta,
-            Clusters& clusters,
             const Eigen::ArrayXd& lambda,
             const std::unique_ptr<Loss>& loss,
             const SortedL1Norm& penalty,
@@ -33,7 +31,6 @@ Hybrid::run(Eigen::VectorXd& beta0,
   runImpl(beta0,
           beta,
           eta,
-          clusters,
           lambda,
           loss,
           penalty,
@@ -50,7 +47,6 @@ void
 Hybrid::run(Eigen::VectorXd& beta0,
             Eigen::VectorXd& beta,
             Eigen::MatrixXd& eta,
-            Clusters& clusters,
             const Eigen::ArrayXd& lambda,
             const std::unique_ptr<Loss>& loss,
             const SortedL1Norm& penalty,
@@ -64,7 +60,6 @@ Hybrid::run(Eigen::VectorXd& beta0,
   runImpl(beta0,
           beta,
           eta,
-          clusters,
           lambda,
           loss,
           penalty,

--- a/src/slope/solvers/hybrid.h
+++ b/src/slope/solvers/hybrid.h
@@ -57,7 +57,6 @@ public:
   void run(Eigen::VectorXd& beta0,
            Eigen::VectorXd& beta,
            Eigen::MatrixXd& eta,
-           Clusters& clusters,
            const Eigen::ArrayXd& lambda,
            const std::unique_ptr<Loss>& loss,
            const SortedL1Norm& penalty,
@@ -72,7 +71,6 @@ public:
   void run(Eigen::VectorXd& beta0,
            Eigen::VectorXd& beta,
            Eigen::MatrixXd& eta,
-           Clusters& clusters,
            const Eigen::ArrayXd& lambda,
            const std::unique_ptr<Loss>& loss,
            const SortedL1Norm& penalty,
@@ -91,7 +89,6 @@ private:
    * @param beta0 Intercept term (scalar)
    * @param beta Coefficients
    * @param eta Linear predictor
-   * @param clusters Coefficient clustering information
    * @param loss Pointer to the loss function
    * @param penalty SLOPE penalty object
    * @param x Design matrix
@@ -103,7 +100,6 @@ private:
   void runImpl(Eigen::VectorXd& beta0,
                Eigen::VectorXd& beta,
                Eigen::MatrixXd& eta,
-               Clusters& clusters,
                const Eigen::ArrayXd& lambda,
                const std::unique_ptr<Loss>& loss,
                const SortedL1Norm& penalty,
@@ -125,7 +121,6 @@ private:
     pgd_solver.run(beta0,
                    beta,
                    eta,
-                   clusters,
                    lambda,
                    loss,
                    penalty,
@@ -136,7 +131,7 @@ private:
                    x_scales,
                    y);
 
-    clusters.update(beta);
+    Clusters clusters(beta);
 
     VectorXd w = VectorXd::Ones(n);
     VectorXd z = y;

--- a/src/slope/solvers/pgd.cpp
+++ b/src/slope/solvers/pgd.cpp
@@ -4,7 +4,6 @@
  */
 
 #include "pgd.h"
-#include "../clusters.h"
 #include "../losses/loss.h"
 #include "../sorted_l1_norm.h"
 #include <Eigen/Dense>
@@ -19,7 +18,6 @@ void
 PGD::run(Eigen::VectorXd& beta0,
          Eigen::VectorXd& beta,
          Eigen::MatrixXd& eta,
-         Clusters& clusters,
          const Eigen::ArrayXd& lambda,
          const std::unique_ptr<Loss>& loss,
          const SortedL1Norm& penalty,
@@ -33,7 +31,6 @@ PGD::run(Eigen::VectorXd& beta0,
   runImpl(beta0,
           beta,
           eta,
-          clusters,
           lambda,
           loss,
           penalty,
@@ -50,7 +47,6 @@ void
 PGD::run(Eigen::VectorXd& beta0,
          Eigen::VectorXd& beta,
          Eigen::MatrixXd& eta,
-         Clusters& clusters,
          const Eigen::ArrayXd& lambda,
          const std::unique_ptr<Loss>& loss,
          const SortedL1Norm& penalty,
@@ -64,7 +60,6 @@ PGD::run(Eigen::VectorXd& beta0,
   runImpl(beta0,
           beta,
           eta,
-          clusters,
           lambda,
           loss,
           penalty,

--- a/src/slope/solvers/pgd.h
+++ b/src/slope/solvers/pgd.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "../clusters.h"
 #include "../losses/loss.h"
 #include "../math.h"
 #include "../sorted_l1_norm.h"
@@ -48,7 +47,6 @@ public:
   void run(Eigen::VectorXd& beta0,
            Eigen::VectorXd& beta,
            Eigen::MatrixXd& eta,
-           Clusters& clusters,
            const Eigen::ArrayXd& lambda,
            const std::unique_ptr<Loss>& loss,
            const SortedL1Norm& penalty,
@@ -63,7 +61,6 @@ public:
   void run(Eigen::VectorXd& beta0,
            Eigen::VectorXd& beta,
            Eigen::MatrixXd& eta,
-           Clusters& clusters,
            const Eigen::ArrayXd& lambda,
            const std::unique_ptr<Loss>& loss,
            const SortedL1Norm& penalty,
@@ -79,7 +76,6 @@ private:
   void runImpl(Eigen::VectorXd& beta0,
                Eigen::VectorXd& beta,
                Eigen::MatrixXd& eta,
-               Clusters&,
                const Eigen::ArrayXd& lambda,
                const std::unique_ptr<Loss>& loss,
                const SortedL1Norm& penalty,

--- a/src/slope/solvers/solver.h
+++ b/src/slope/solvers/solver.h
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "../clusters.h"
 #include "../jit_normalization.h"
 #include "../losses/loss.h"
 #include "../sorted_l1_norm.h"
@@ -53,7 +52,6 @@ public:
    * @param beta0 Intercept terms for each response
    * @param beta Coefficients (size p x m)
    * @param eta Linear predictor matrix (n samples x m responses)
-   * @param clusters Coefficient clustering structure
    * @param lambda Vector of regularization parameters
    * @param loss Pointer to loss function object
    * @param penalty Sorted L1 norm object for proximal operations
@@ -67,7 +65,6 @@ public:
   virtual void run(Eigen::VectorXd& beta0,
                    Eigen::VectorXd& beta,
                    Eigen::MatrixXd& eta,
-                   Clusters& clusters,
                    const Eigen::ArrayXd& lambda,
                    const std::unique_ptr<Loss>& loss,
                    const SortedL1Norm& penalty,
@@ -84,7 +81,6 @@ public:
    * @param beta0 Intercept terms for each response
    * @param beta Coefficient vecttor (size p x m)
    * @param eta Linear predictor matrix (n samples x m responses)
-   * @param clusters Coefficient clustering structure
    * @param lambda Vector of regularization parameters
    * @param loss Pointer to loss function object
    * @param penalty Sorted L1 norm object for proximal operations
@@ -98,7 +94,6 @@ public:
   virtual void run(Eigen::VectorXd& beta0,
                    Eigen::VectorXd& beta,
                    Eigen::MatrixXd& eta,
-                   Clusters& clusters,
                    const Eigen::ArrayXd& lambda,
                    const std::unique_ptr<Loss>& loss,
                    const SortedL1Norm& penalty,

--- a/tests/path.cpp
+++ b/tests/path.cpp
@@ -123,4 +123,17 @@ TEST_CASE("Path fitting", "[path][quadratic][alpha]")
 
     REQUIRE_NOTHROW(model.path(data.x, data.y, alpha, lambda));
   }
+
+  SECTION("Return clusters")
+  {
+    slope::Slope model;
+    model.setPathLength(84);
+    model.setReturnClusters(true);
+
+    auto data = generateData(100, 10);
+
+    auto path = model.path(data.x, data.y);
+
+    REQUIRE(path.getClusters().size() > 0);
+  }
 }


### PR DESCRIPTION
This removes unnecessary bloat from other solvers that don't utilize
this object. Closes #56.

feat: add `getClusters()` for `SlopeFit` and `SlopePath` to return the
clusters from a Slope fit. Set to `false` by default to not use up extra
memory. Closes #102.