### PR TITLE
feat!: use non-redundant multinomial logistic formulation

### DIFF
--- a/src/slope/losses/multinomial.cpp
+++ b/src/slope/losses/multinomial.cpp
@@ -25,24 +25,30 @@ Multinomial::dual(const Eigen::MatrixXd& theta,
                   const Eigen::MatrixXd& y,
                   const Eigen::VectorXd&)
 {
-  const Eigen::MatrixXd r = theta + y;
+  int n = y.rows();
+  int p = y.cols();
 
-  return -(r.array() * r.array().max(constants::P_MIN).log()).sum() / y.rows();
+  Eigen::ArrayXXd eta = link(theta + y);
+
+  // TODO: Find out if this formulation can be improved numerically
+  double out = logSumExp(eta).mean() - (y.array() * eta).sum() / n -
+               (theta.array() * eta).sum() / n;
+
+  return out;
 }
 
 Eigen::MatrixXd
 Multinomial::preprocessResponse(const Eigen::MatrixXd& y)
 {
   const int n = y.rows();
-  int m = y.cols();
 
   Eigen::MatrixXd result;
 
-  if (m == 1) {
-    // Y is a column vector, expect integers representing classes
-    m = y.array().maxCoeff() + 1; // Assuming classes are 0-based
+  if (y.cols() == 1) {
+    // y is a column vector, expect integers representing classes
+    int m = y.array().maxCoeff(); // Assuming classes are 0-based
 
-    if (m == 1) {
+    if (m == 0) {
       throw std::invalid_argument("Only one class found in response");
     }
 
@@ -55,7 +61,9 @@ Multinomial::preprocessResponse(const Eigen::MatrixXd& y)
           "Class labels must be consecutive integers starting from 0");
       }
 
-      result(i, class_label) = 1.0;
+      if (class_label < m) {
+        result(i, class_label) = 1.0;
+      }
     }
   } else {
     // Y is a matrix, expect one-hot encoding
@@ -73,7 +81,7 @@ Multinomial::preprocessResponse(const Eigen::MatrixXd& y)
       }
     }
 
-    result = y;
+    return y;
   }
 
   return result;
@@ -82,16 +90,30 @@ Multinomial::preprocessResponse(const Eigen::MatrixXd& y)
 Eigen::MatrixXd
 Multinomial::hessianDiagonal(const Eigen::MatrixXd& eta)
 {
-  auto pr = inverseLink(eta);
-  return pr.array() * (1 - pr.array());
+  Eigen::MatrixXd pr = inverseLink(eta);
+
+  return pr.array() * (1.0 - pr.array());
 }
 
 Eigen::MatrixXd
 Multinomial::link(const Eigen::MatrixXd& mu)
 {
-  return mu.unaryExpr([](const double& x) {
-    return logit(std::clamp(x, constants::P_MIN, constants::P_MAX));
-  });
+  Eigen::MatrixXd out(mu.rows(), mu.cols());
+
+  for (int i = 0; i < mu.rows(); i++) {
+    double row_sum = mu.row(i).sum();
+    double ref_val = 1.0 - row_sum;
+
+    for (int j = 0; j < mu.cols(); j++) {
+      double numerator =
+        std::clamp(mu(i, j), constants::P_MIN, constants::P_MAX);
+      double denominator =
+        std::clamp(ref_val, constants::P_MIN, constants::P_MAX);
+      out(i, j) = std::log(numerator) - std::log(denominator);
+    }
+  }
+
+  return out;
 }
 
 Eigen::MatrixXd
@@ -103,13 +125,20 @@ Multinomial::inverseLink(const Eigen::MatrixXd& eta)
 Eigen::MatrixXd
 Multinomial::predict(const Eigen::MatrixXd& eta)
 {
-  Eigen::MatrixXd prob = inverseLink(eta);
+  int n = eta.rows();
+  int m = eta.cols();
+
+  // Directly compute probabilities with the last column as reference class
+  Eigen::MatrixXd prob = softmax(eta);
 
   // Find the class with the highest probability
-  Eigen::VectorXd out(eta.rows());
+  Eigen::VectorXd out(n);
+  for (int i = 0; i < n; i++) {
+    double sum_prob = prob.row(i).sum();
+    double best_prob = prob.row(i).maxCoeff();
+    double ref_prob = 1.0 - sum_prob;
 
-  for (int i = 0; i < eta.rows(); i++) {
-    out(i) = whichMax(prob.row(i));
+    out(i) = best_prob > ref_prob ? whichMax(prob.row(i)) : m;
   }
 
   return out;

--- a/src/slope/losses/multinomial.h
+++ b/src/slope/losses/multinomial.h
@@ -14,8 +14,9 @@ namespace slope {
  * loss function.
  * @details The multinomial loss function is used for multi-class
  * classification problems. It calculates the loss, dual, residual, and updates
- * weights and working response. Assumes the response y is a one-hot encoded
- * matrix where each row sums to 1.
+ * weights and working response. It uses the non-redundant formulation
+ * of the loss with \f( K - 1\f) columns in the resulting
+ * response matrix.
  */
 class Multinomial : public Loss
 {
@@ -26,8 +27,8 @@ public:
   }
   /**
    * @brief Calculates the loss for the multinomial loss function.
-   * @param eta The predicted values (n x k matrix of linear predictors).
-   * @param y The true labels (n x k matrix of one-hot encoded class
+   * @param eta The predicted values (n x m matrix of linear predictors).
+   * @param y The true labels (n x m matrix of one-hot encoded class
    * memberships).
    * @return The loss value.
    */
@@ -35,9 +36,8 @@ public:
 
   /**
    * @brief Calculates the dual for the multinomial loss function.
-   * @param theta The dual variables (n x k matrix).
-   * @param y The true labels (n x k matrix of one-hot encoded class
-   * memberships).
+   * @param theta The dual variables (n x m matrix).
+   * @param y The true labels (n x m matrix).
    * @param w The weights vector.
    * @return The dual value.
    */
@@ -47,17 +47,18 @@ public:
 
   /**
    * @brief Preprocesses the response for the Multinomial model
-   * @param y Predicted values vector (n x 1) of integer class labels
-   * @return Matrix of response (n x 1)
+   * @param y Vector of class labels (n x 1). Each entry is an integer
+   * representing the class label from 0 to m.
+   * @return Matrix of response (n x m)
    */
   Eigen::MatrixXd preprocessResponse(const Eigen::MatrixXd& y);
 
   /**
-   * @brief Calculates hessian diagonal
+   * @brief Calculates the hessian diagonal
    *
    * @param eta Linear predictor
    * @param y Response
-   * @return A matrix of ones (n x m)
+   * @return The hessian diagonal, a matrix of size (n x m)
    */
   Eigen::MatrixXd hessianDiagonal(const Eigen::MatrixXd& eta);
 
@@ -69,10 +70,10 @@ public:
   Eigen::MatrixXd link(const Eigen::MatrixXd& mu);
 
   /**
-   * @brief The inverse link function, also known as the mean function.
+   * @brief The inverse link function
    * @param eta
-   * @return The softmax of the linear predictor: \f$
-   * \frac{e^{\eta}}{\sum_{j=1}^{k} e^{\eta_j}} \f$
+   * @return The modified softmax of the linear predictor: \f$
+   * \frac{e^{\eta}}{1 + \sum_{j=1}^{k} e^{\eta_j}} \f$
    */
   Eigen::MatrixXd inverseLink(const Eigen::MatrixXd& eta);
 

--- a/src/slope/math.cpp
+++ b/src/slope/math.cpp
@@ -6,11 +6,12 @@ namespace slope {
 Eigen::VectorXd
 logSumExp(const Eigen::MatrixXd& a)
 {
-  Eigen::VectorXd max_vals = a.rowwise().maxCoeff();
+  Eigen::ArrayXd max_vals = a.rowwise().maxCoeff();
   Eigen::ArrayXd sum_exp =
-    (a.colwise() - max_vals).array().exp().rowwise().sum();
+    (-max_vals).exp() +
+    (a.colwise() - max_vals.matrix()).array().exp().rowwise().sum();
 
-  return max_vals.array() + sum_exp.max(constants::P_MIN).log();
+  return max_vals + sum_exp.max(constants::P_MIN).log();
 }
 
 Eigen::MatrixXd
@@ -19,7 +20,8 @@ softmax(const Eigen::MatrixXd& a)
   Eigen::VectorXd shift = a.rowwise().maxCoeff();
   Eigen::MatrixXd exp_a = (a.colwise() - shift).array().exp();
   Eigen::ArrayXd row_sums = exp_a.rowwise().sum();
-  return exp_a.array().colwise() / row_sums;
+
+  return exp_a.array().colwise() / ((-shift).array().exp() + row_sums);
 }
 
 std::vector<int>

--- a/src/slope/slope.cpp
+++ b/src/slope/slope.cpp
@@ -16,6 +16,7 @@
 #include "utils.h"
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
+#include <iostream>
 #include <memory>
 #include <numeric>
 #include <set>
@@ -235,6 +236,8 @@ Slope::path(T& x,
       }
 
       double dual_gap = primal - dual;
+
+      // std::cout << "gap: " << dual_gap << std::endl;
 
       assert(dual_gap > -1e-6 && "Dual gap should be positive");
 

--- a/src/slope/solvers/setup_solver.cpp
+++ b/src/slope/solvers/setup_solver.cpp
@@ -19,7 +19,8 @@ setupSolver(const std::string& solver_type,
   if (solver_type == "auto") {
     // TODO: Make this more sophisticated, e.g. define in solver class
     // and check if compatible with the loss function.
-    solver_choice = loss == "multinomial" ? "fista" : "hybrid";
+    // solver_choice = loss == "multinomial" ? "fista" : "hybrid";
+    solver_choice = "hybrid";
   }
 
   if (solver_choice == "pgd") {

--- a/tests/math.cpp
+++ b/tests/math.cpp
@@ -2,11 +2,11 @@
 #include "generate_data.hpp"
 #include "slope/normalize.h"
 #include "test_helpers.hpp"
-#include <slope/threads.h>
 #include <Eigen/Core>
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <slope/threads.h>
 
 TEST_CASE("Linear predictor computations", "[math][linearPredictor]")
 {
@@ -618,4 +618,28 @@ TEST_CASE("Gradient offset calculations", "[math][offsetGradient]")
     REQUIRE_THAT(gradient_dense(0) - gradient_dense_copy(0),
                  WithinAbs(expected_offset_0_0, 1e-10));
   }
+}
+
+TEST_CASE("logSumExp", "[math]")
+{
+  Eigen::ArrayXXd x(2, 3);
+
+  x << -0.5, 2, 0.1, 5, 3, 0.01;
+
+  auto out = slope::logSumExp(x);
+  Eigen::VectorXd ref = (1.0 + x.exp().rowwise().sum()).log();
+
+  REQUIRE_THAT(out, VectorApproxEqual(ref));
+}
+
+TEST_CASE("softmax", "[math]")
+{
+  Eigen::ArrayXXd x(2, 3);
+
+  x << -0.1, 0.05, 0.1, -0.9, 2.5, 0.01;
+
+  auto out = slope::softmax(x);
+  Eigen::MatrixXd ref = x.exp().colwise() / (1.0 + x.exp().rowwise().sum());
+
+  REQUIRE_THAT(out.reshaped(), VectorApproxEqual(ref.reshaped()));
 }


### PR DESCRIPTION
Switches to the non-redundant formulation of the multinomial logistic
loss function, using the last class as the reference.

The implementation for the dual is just the generic formulation and could probably be improved.